### PR TITLE
Optional naming of internal node

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Takes as input the following arguments:
       either a leaf node or internal node.
     * `size` The size of the internal node, with the same specifications
       as values within `sizes` (see next bullet point).
+    * optional `name` in order to get position and size of this internal node.
 * `sizes` An object that specifies component size options, where
   * Keys are component alias strings.
   * Values are objects with the following properties:
@@ -110,5 +111,6 @@ Returns an object where
   * `y` The Y offset of the box in pixels.
   * `width` The width of the box in pixels.
   * `height` The height of the box in pixels.
+  * `nonleaf` A boolean (true/ undefined) in case of a named internal node (composed boxe).
   * These box dimensions are quantized from floats to ints such that there are no gaps.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-boxes",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Nested box layout for use with D3 visualizations.",
   "keywords": [
     "d3",

--- a/src/boxes.js
+++ b/src/boxes.js
@@ -83,7 +83,8 @@ export default function boxes(layout, sizes, box){
       if(isLeafNode(child)){
         result[child] = childBox;
       } else {
-        var childResult = boxes(child, sizes, childBox); 
+        var childResult = boxes(child, sizes, childBox);
+        if (child.name) {result[child.name] = childBox; result[child.name].nonleaf = true;};
         Object.keys(childResult).forEach(function (alias){
           result[alias] = childResult[alias];
         });

--- a/test/boxes-test.js
+++ b/test/boxes-test.js
@@ -434,4 +434,24 @@ describe("boxes", function () {
     expect(result.a.width + result.b.width + result.c.width).to.equal(100);
 
   });
+
+  it("named internal node", function() {
+     var layout = {
+          orientation: "horizontal",
+          children: [
+            {orientation: "vertical",
+              children: ["a1", "a2"],
+              name: "a"
+            }, 
+            "b",
+            "c"]
+        },
+        box = { width: 100, height: 100 },
+        result = boxes(layout, null, box);
+    expect(result.a.x).to.equal(0);
+    expect(result.a.y).to.equal(0);
+    expect(result.a.width).to.equal(33);
+    expect(result.a.height).to.equal(100);
+    expect(result.a.nonleaf).to.equal(true);
+ });
 });


### PR DESCRIPTION
Should add possibilities, while causing no harm to the existing usages.

My application is to draw no or thick borders around boxes or group of boxes.

 